### PR TITLE
Add uninstall button to Docker Desktop

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -108,7 +108,12 @@ function App() {
 
         <Grid container mt={2} columnSpacing={2}>
           <Grid item xs={8}>
-            <Installer domain={domain} enabled={hasKubernetes} onInstallationChanged={setInstallation} onError={handleError}/>
+            <Installer
+              domain={domain}
+              hasKubernetes={hasKubernetes}
+              installation={installation}
+              onInstallationChanged={setInstallation}
+              onError={handleError} />
           </Grid>
 
           <Grid item xs={4}>

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -1,6 +1,7 @@
 import React from "react";
 import {Box, Button, Card, CardActions, CardContent, LinearProgress, Typography} from "@mui/material";
 import InstallDesktopIcon from '@mui/icons-material/InstallDesktop';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 class EpinioInstaller extends React.Component {
   constructor(props) {
@@ -145,10 +146,10 @@ class EpinioInstaller extends React.Component {
           </Typography>
         </CardContent>
         <CardActions>
-          <Button startIcon={<InstallDesktopIcon/>} variant="outlined" onClick={this.install} disabled={disabled}>
+          <Button startIcon={<InstallDesktopIcon/>} variant="contained" onClick={this.install} disabled={disabled}>
             Install/Upgrade
           </Button>
-          <Button variant="outlined" onClick={this.uninstall} disabled={disabled}>
+          <Button startIcon={<DeleteIcon/>} variant="outlined" onClick={this.uninstall} disabled={disabled} color="secondary">
             Uninstall
           </Button>
         </CardActions>

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -149,7 +149,7 @@ class EpinioInstaller extends React.Component {
           <Button startIcon={<InstallDesktopIcon/>} variant="contained" onClick={this.install} disabled={disabled}>
             Install/Upgrade
           </Button>
-          <Button startIcon={<DeleteIcon/>} variant="outlined" onClick={this.uninstall} disabled={disabled} color="secondary">
+          <Button startIcon={<DeleteIcon/>} variant="contained" onClick={this.uninstall} disabled={disabled} color="secondary">
             Uninstall
           </Button>
         </CardActions>

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -119,9 +119,10 @@ class EpinioInstaller extends React.Component {
       // https://github.com/docker/for-mac/issues/4903
       console.log("nginx successfully uninstalled");
       this.setState({progress: 100});
-
-    } catch (error) {
       this.props.onInstallationChanged(false);
+    } 
+    catch (error) {
+      this.props.onInstallationChanged(true);
       var msg = "If the nginx service is stuck in pending state, you might need to restart docker desktop." + <br/> + error.message;
       this.props.onError(msg);
       return;

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -7,6 +7,7 @@ class EpinioInstaller extends React.Component {
     super(props);
     this.state = {progress: 0};
     this.install = this.install.bind(this);
+    this.uninstall = this.uninstall.bind(this);
   }
 
   async helm(args) {
@@ -147,10 +148,8 @@ class EpinioInstaller extends React.Component {
           <Button startIcon={<InstallDesktopIcon/>} variant="outlined" onClick={this.install} disabled={disabled}>
             Install/Upgrade
           </Button>
-        </CardActions>
-        <CardActions>
           <Button variant="outlined" onClick={this.uninstall} disabled={disabled}>
-            Unistall
+            Uninstall
           </Button>
         </CardActions>
         <Box sx={{ width: '100%' }}>

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -81,6 +81,52 @@ class EpinioInstaller extends React.Component {
 
   }
 
+  async uninstall() {
+    try {
+      console.log("uninstalling Epinio chart");
+      this.setState({progress: 10});
+      result = await this.helm([
+        "uninstall", "--wait", "epinio",
+        "--namespace", "epinio"
+      ]);
+      console.debug(JSON.stringify(result));
+      console.log(result.stdout);
+      console.log("installed: epinio");
+      this.setState({progress: 25});
+      this.props.onInstallationChanged(true);
+
+      console.log("uninstalling cert-manager chart");
+      this.setState({progress: 30});
+      result = await this.helm([
+        "uninstall", "--wait", "cert-manager",
+        "--namespace", "cert-manager"
+      ]);
+      console.debug(JSON.stringify(result));
+      console.log(result.stdout);
+      console.log("uninstalled: cert-manager");
+      this.setState({progress: 50});
+
+      console.log("uninstalling NGINX chart");
+      this.setState({progress: 75});
+      let result = await this.helm([
+        "uninstall", "--wait", "ingress-nginx",
+        "--namespace", "ingress-nginx"
+      ]);
+      console.debug(JSON.stringify(result));
+      console.log(result.stdout);
+      // https://github.com/docker/for-mac/issues/4903
+      console.log("nginx successfully uninstalled");
+      this.setState({progress: 100});
+
+    } catch (error) {
+      this.props.onInstallationChanged(false);
+      var msg = "If the nginx service is stuck in pending state, you might need to restart docker desktop." + <br/> + error.message;
+      this.props.onError(msg);
+      return;
+    }
+
+  }
+
   render() {
     // TODO install is idempotent, but maybe also detect working installation?
     const progress = this.state.progress === 100 || this.state.progress === 0 ? null : <LinearProgress variant="determinate" value={this.state.progress} />;
@@ -100,6 +146,11 @@ class EpinioInstaller extends React.Component {
         <CardActions>
           <Button startIcon={<InstallDesktopIcon/>} variant="outlined" onClick={this.install} disabled={disabled}>
             Install/Upgrade
+          </Button>
+        </CardActions>
+        <CardActions>
+          <Button variant="outlined" onClick={this.uninstall} disabled={disabled}>
+            Unistall
           </Button>
         </CardActions>
         <Box sx={{ width: '100%' }}>


### PR DESCRIPTION
Implements: https://github.com/epinio/extension-docker-desktop/issues/22

### Done:
- Added `uninstall` button by the use of   `async uninstall()`uninstall function which basically reverts the original ``async install()``

![image](https://user-images.githubusercontent.com/37271841/228212431-224f0b7e-4d31-4baf-8d6e-26247f0901b2.png)

![image](https://user-images.githubusercontent.com/37271841/228213157-a054aa66-955b-48ac-94df-a889cf5c33a0.png)



### Caveats:
- No alert dialog prior to uninstalling. Leaving up to the team if we want to implement it. Given that this button uninstalls Epinio but not the app, I guess it may not be a big issue. ITried to implement it using these articles as references but got issues:
   - https://christopher-dent.medium.com/adding-a-delete-confirmation-to-your-react-app-55221701daa6 
   - https://plainenglish.io/blog/creating-a-confirm-dialog-in-react-and-material-ui



- Once uninstalled, since there is no refresh mechanism some of the active elements like the version or link to the UI will be active until some kind of refresh or navigating to other buttons is done

### Notes on how to run local build
- Have Docker Desktop Extension ready (recommendation, uninstall previous Epinio extensions if exist)
- On `extension-docker-desktop` repo, run `make`
- `docker login`
- Tag the image created, push it and install extension. As example:
```
docker tag d6dbc7361b23 mmartin24/extension-linux:latest
docker push mmartin24/extension-linux:latest
docker extension install mmartin24/extension-linux:latest
```
