### PR TITLE
Code cleanup with more spacing linters

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -25,12 +25,13 @@ module.exports = {
     quotes: 'off',
     semi: 'off',
     'no-undef': 'off',
-    'object-property-newline': 'off',
-    'object-shorthand': 'off',
-    'padded-blocks': 'off',
-    'space-before-function-paren': 'off',
-    'react/no-unescaped-entities': 'off',
-    'react/prop-types': 'off',
-    'react/react-in-jsx-scope': 'off'
+    'space-before-function-paren': [
+      'error',
+      {
+        anonymous: 'always',
+        named: 'never'
+      }
+    ],
+    'react/prop-types': 'off'
   }
 }

--- a/ui/src/App.test.js
+++ b/ui/src/App.test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import App from './App'
 

--- a/ui/src/KubernetesCheck.js
+++ b/ui/src/KubernetesCheck.js
@@ -21,7 +21,7 @@ class KubernetesCheck extends React.Component {
 
   setRunning(val, node, error) {
     this.props.onEnabledChanged(val);
-    this.setState({ node: node, error: error });
+    this.setState({ node, error });
   }
 
   async check() {
@@ -36,7 +36,6 @@ class KubernetesCheck extends React.Component {
 
       const node = obj.items[0].metadata.name;
       this.setRunning(true, node, "");
-
     } catch (error) {
       if (error instanceof Error) {
         this.setRunning(false, "", error.message)
@@ -62,7 +61,7 @@ function KubernetesOK(props) {
 
   return <Alert severity="info">
     Kubernetes is running, however you are not connected to a Docker Desktop node.
-    The "Install" button might not work with other clusters.
+    The &quot;Install&quot; button might not work with other clusters.
   </Alert>
 }
 
@@ -70,7 +69,7 @@ function KubernetesMissing(props) {
   const errmsg = props.error ? <p>{props.error}</p> : null;
   return (
     <Alert severity="error">
-      You need a Kubernetes cluster to use Epinio. Go to 'Preferences -&gt; Kubernetes' and enable it. Make sure to select the right Kubernetes context.
+      You need a Kubernetes cluster to use Epinio. Go to &apos;Preferences -&gt; Kubernetes&apos; and enable it. Make sure to select the right Kubernetes context.
 
       {errmsg}
     </Alert>

--- a/ui/src/epinio/API.js
+++ b/ui/src/epinio/API.js
@@ -99,7 +99,10 @@ export class Lister extends React.Component {
       { field: "state", headerName: "State", sortable: true, width: "80" },
       { field: "instances", headerName: "Instances", type: "number", width: "80" },
       {
-        field: "route", headerName: "Route", width: "160", renderCell: (params) => {
+        field: "route",
+        headerName: "Route",
+        width: "160",
+        renderCell: (params) => {
           const open = () => {
             window.ddClient.host.openExternal("https://" + params.row.route);
           };

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -76,7 +76,6 @@ class EpinioInstaller extends React.Component {
       console.log("installed: epinio");
       this.setState({ progress: 100 });
       this.props.onInstallationChanged(true);
-
     } catch (error) {
       this.props.onInstallationChanged(false);
       const msg = "If the nginx service is stuck in pending state, you might need to restart docker desktop." + <br/> + error.message;
@@ -121,7 +120,6 @@ class EpinioInstaller extends React.Component {
       console.log("nginx successfully uninstalled");
       this.setState({ progress: 100 });
       this.props.onInstallationChanged(false);
-
     } catch (error) {
       this.props.onInstallationChanged(true);
       const msg = "If the nginx service is stuck in pending state, you might need to restart docker desktop." + <br/> + error.message;


### PR DESCRIPTION
Cleanup code with more spacing linters.

Removed:
```js
'object-property-newline'
'object-shorthand'
'padded-blocks'
'react/no-unescaped-entities'
'react/react-in-jsx-scope'
```

Configured the `space-before-function-paren` linter to force space for `anon` functions and have no space for non-anonymous functions:

```js
'space-before-function-paren': [
    'error',
    {
        anonymous: 'always',
        named: 'never'
    }
]
```