### PR TITLE
Changing `nginx` ingress to `traefik`, use Epinio CLI instead of APIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ARG KUBECTL_CHECKSUM_LINUX_AMD64=aaa5ea3b3630730d2b8a8ef3cccb14b47754602c7207c7b
 ARG KUBECTL_CHECKSUM_WINDOWS_AMD64=ed404eb0c3b74341d2ff799e78f9c0352e2bbd5c1b645652de2725ec77c0a78e
 
 # https://github.com/epinio/epinio/releases
-ARG EPINIO_VERSION=1.11.0-rc1
+ARG EPINIO_VERSION=1.11.0
 
 # /darwin amd64
 RUN wget -nv https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz && \
@@ -113,7 +113,7 @@ ARG KUBECTL_CHECKSUM_DARWIN_ARM64=4166d293b4f58e5293363f1f91a285d929a54557bf0c1a
 ARG KUBECTL_CHECKSUM_LINUX_ARM64=741e65b681a22074aaf9459b57dbcef6a9e993472b3019a87f57c191bc68575f
 
 # https://github.com/epinio/epinio/releases
-ARG EPINIO_VERSION=1.11.0-rc1
+ARG EPINIO_VERSION=1.11.0
 
 # /darwin arm64
 RUN wget -nv https://get.helm.sh/helm-v${HELM_VERSION}-darwin-arm64.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ ARG KUBECTL_CHECKSUM_LINUX_AMD64=aaa5ea3b3630730d2b8a8ef3cccb14b47754602c7207c7b
 ARG KUBECTL_CHECKSUM_WINDOWS_AMD64=ed404eb0c3b74341d2ff799e78f9c0352e2bbd5c1b645652de2725ec77c0a78e
 
 # https://github.com/epinio/epinio/releases
-ARG EPINIO_VERSION=1.10.0
+ARG EPINIO_VERSION=1.11.0-rc1
 
 # /darwin amd64
 RUN wget -nv https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz && \
@@ -113,7 +113,7 @@ ARG KUBECTL_CHECKSUM_DARWIN_ARM64=4166d293b4f58e5293363f1f91a285d929a54557bf0c1a
 ARG KUBECTL_CHECKSUM_LINUX_ARM64=741e65b681a22074aaf9459b57dbcef6a9e993472b3019a87f57c191bc68575f
 
 # https://github.com/epinio/epinio/releases
-ARG EPINIO_VERSION=1.10.0
+ARG EPINIO_VERSION=1.11.0-rc1
 
 # /darwin arm64
 RUN wget -nv https://get.helm.sh/helm-v${HELM_VERSION}-darwin-arm64.tar.gz && \

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -93,7 +93,12 @@ function App() {
         </Modal>
         </div>
 
-        <Credentials enabled={hasKubernetes} credentials={credentials} onCredentialsChanged={setCredentials} installation={installation} />
+        <Credentials
+          enabled={hasKubernetes}
+          credentials={credentials}
+          onCredentialsChanged={setCredentials}
+          installation={installation}
+          domain={domain} />
 
         <Box sx={{ width: '100%' }}>
           <Typography variant="subtitle1" component="div" gutterBottom>

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -138,7 +138,7 @@ function App() {
           <BottomNavigation showLabels sx={{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
             <Info apiDomain={uiDomain} enabled={hasKubernetes} credentials={credentials} info={epinioInfo} onInfoChanged={setEpinioInfo} />
             <BottomNavigationAction label="epinio.io" icon={<HomeIcon />} onClick={openURL} url="https://epinio.io" />
-            <BottomNavigationAction label="CLI" icon={<DownloadIcon />} onClick={openURL} url="https://github.com/epinio/epinio/releases/tag/v1.10.0" />
+            <BottomNavigationAction label="CLI" icon={<DownloadIcon />} onClick={openURL} url="https://github.com/epinio/epinio/releases/tag/v1.11.0" />
           </BottomNavigation>
         </Paper>
 

--- a/ui/src/epinio/API.js
+++ b/ui/src/epinio/API.js
@@ -18,18 +18,11 @@ export default function EpinioClient({
   const info = async () => {
     console.log('EpinioClient.info')
 
-    // TODO: update with '--output json' flag
-    const result = await epinio(['info'])
-    const lines = result.split('\n')
+    const result = await epinio([
+      'info', '--output', 'json'
+    ])
 
-    for (const i in lines) {
-      if (lines[i].indexOf('Epinio Server Version: ') === 0) {
-        const version = lines[i].replace('Epinio Server Version: ', '')
-        return { version }
-      }
-    }
-
-    return { version: 'unknown' }
+    return JSON.parse(result)
   }
 
   const listApplications = async (namespace) => {

--- a/ui/src/epinio/Credentials.js
+++ b/ui/src/epinio/Credentials.js
@@ -1,5 +1,9 @@
 import React from 'react'
 
+function credsChanged(creds, update) {
+  return creds.username !== update.username || creds.password !== update.password
+}
+
 export function credentialsOK(creds) {
   return creds && creds.username !== '-' && creds.password !== '-'
 }
@@ -8,8 +12,18 @@ export function credentialsOK(creds) {
 function Credentials(props) {
   React.useEffect(() => {
     const getCredentials = async () => {
-      // TODO: hardcoded user
-      props.onCredentialsChanged({ username: 'admin', password: 'password' })
+      try {
+        await epinioClient.login('admin', 'password')
+        const u = { username: 'admin', password: 'password' }
+        if (credsChanged(props.credentials, u)) {
+          props.onCredentialsChanged(u)
+        }
+      } catch (error) {
+        const u = { username: '-', password: '-' }
+        if (credsChanged(props.credentials, u)) {
+          props.onCredentialsChanged(u)
+        }
+      }
     }
     if (props.enabled) {
       getCredentials()

--- a/ui/src/epinio/Credentials.js
+++ b/ui/src/epinio/Credentials.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import EpinioClient from './API'
 
 function credsChanged(creds, update) {
   return creds.username !== update.username || creds.password !== update.password
@@ -11,22 +12,36 @@ export function credentialsOK(creds) {
 // Credentials will fetch the default user, when props.enabled is true
 function Credentials(props) {
   React.useEffect(() => {
-    const getCredentials = async () => {
+    const epinioClient = EpinioClient({ apiDomain: props.domain })
+
+    const login = async () => {
+      let u = { username: '-', password: '-' }
+
       try {
         await epinioClient.login('admin', 'password')
-        const u = { username: 'admin', password: 'password' }
-        if (credsChanged(props.credentials, u)) {
-          props.onCredentialsChanged(u)
-        }
+        u = { username: 'admin', password: 'password' }
       } catch (error) {
-        const u = { username: '-', password: '-' }
-        if (credsChanged(props.credentials, u)) {
-          props.onCredentialsChanged(u)
-        }
+        // fail
+      }
+
+      if (credsChanged(props.credentials, u)) {
+        props.onCredentialsChanged(u)
       }
     }
+
+    const logout = async () => {
+      await epinioClient.logout()
+
+      const u = { username: '-', password: '-' }
+      if (credsChanged(props.credentials, u)) {
+        props.onCredentialsChanged(u)
+      }
+    }
+
     if (props.enabled) {
-      getCredentials()
+      login()
+    } else {
+      logout()
     }
   }, [props])
 

--- a/ui/src/epinio/Credentials.js
+++ b/ui/src/epinio/Credentials.js
@@ -1,9 +1,5 @@
 import React from 'react'
 
-function credsChanged(creds, update) {
-  return creds.username !== update.username || creds.password !== update.password
-}
-
 export function credentialsOK(creds) {
   return creds && creds.username !== '-' && creds.password !== '-'
 }
@@ -12,31 +8,8 @@ export function credentialsOK(creds) {
 function Credentials(props) {
   React.useEffect(() => {
     const getCredentials = async () => {
-      try {
-        // note: `-l` returns a list, hence the `.items...`, even if only a single secret matches
-        const result = await window.ddClient.extension.host.cli.exec(
-          'kubectl',
-          ['get', 'secret', '-n', 'epinio', '-l', 'epinio.io/role=admin', '-o', 'jsonpath={.items[0].data}']
-        )
-        result.parseJsonObject()
-        // Retrieval above as check that epinio is present.
-        // Creds hardwired, unchanged from defaults
-        const u = { username: 'admin', password: 'password' }
-        if (credsChanged(props.credentials, u)) {
-          props.onCredentialsChanged(u)
-        }
-      } catch (error) {
-        // for debugging:
-        // if (error instanceof Error) {
-        //   console.error(error);
-        // } else {
-        //   console.log(JSON.stringify(error));
-        // }
-        const u = { username: '-', password: '-' }
-        if (credsChanged(props.credentials, u)) {
-          props.onCredentialsChanged(u)
-        }
-      }
+      // TODO: hardcoded user
+      props.onCredentialsChanged({ username: 'admin', password: 'password' })
     }
     if (props.enabled) {
       getCredentials()

--- a/ui/src/epinio/Credentials.js
+++ b/ui/src/epinio/Credentials.js
@@ -21,7 +21,7 @@ function Credentials(props) {
         await epinioClient.login('admin', 'password')
         u = { username: 'admin', password: 'password' }
       } catch (error) {
-        // fail
+        console.error(error)
       }
 
       if (credsChanged(props.credentials, u)) {

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -83,7 +83,7 @@ export default function EpinioInstaller({
       setInstalled(false)
       onInstallationChanged(false)
 
-      message = 'Error installing Epinio'
+      let message = 'Error installing Epinio'
       if (error.stderr) {
         message = error.stderr
       }

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -52,10 +52,6 @@ export default function EpinioInstaller({
   async function install() {
     try {
       setProgress(10)
-      await installNginx()
-      setProgress(25)
-
-      setProgress(30)
       await installCertManager()
       setProgress(50)
 
@@ -83,12 +79,8 @@ export default function EpinioInstaller({
       await uninstallEpinio()
       setProgress(25)
 
-      setProgress(30)
-      await uninstallCertManager()
       setProgress(50)
-
-      setProgress(75)
-      await uninstallNginx()
+      await uninstallCertManager()
       setProgress(100)
 
       onInstallationChanged(true)
@@ -99,20 +91,6 @@ export default function EpinioInstaller({
     } finally {
       setProgress(0)
     }
-  }
-
-  const installNginx = async () => {
-    console.log('installing nginx chart')
-
-    await helm([
-      'upgrade', '--install', '--atomic', 'ingress-nginx',
-      '--create-namespace', '--namespace', 'ingress-nginx',
-      'https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.7.1/ingress-nginx-4.7.1.tgz'
-    ])
-
-    // https://github.com/docker/for-mac/issues/4903
-    console.log('installed: nginx')
-    console.log("you might need to restart docker-desktop if localhost:443 doesn't forward to nginx")
   }
 
   const installCertManager = async () => {
@@ -137,9 +115,7 @@ export default function EpinioInstaller({
       '--create-namespace', '--namespace', 'epinio',
       '--atomic',
       '--set', 'global.domain=' + domain,
-      '--set', 'ingress.ingressClassName=nginx',
-      '--set', 'ingress.nginxSSLRedirect=false',
-      'https://github.com/epinio/helm-charts/releases/download/epinio-1.10.0/epinio-1.10.0.tgz'
+      'https://github.com/epinio/helm-charts/releases/download/epinio-1.11.0-rc1/epinio-1.11.0-rc1.tgz'
     ])
 
     console.log('installed: epinio')
@@ -165,17 +141,6 @@ export default function EpinioInstaller({
     ])
 
     console.log('uninstalled: cert-manager')
-  }
-
-  const uninstallNginx = async () => {
-    console.log('uninstalling nginx chart')
-
-    await helm([
-      'uninstall', '--namespace', 'ingress-nginx',
-      '--wait', 'ingress-nginx'
-    ])
-
-    console.log('uninstalled: nginx')
   }
 
   // spawn epinio status check only once

--- a/ui/src/epinio/Installer.js
+++ b/ui/src/epinio/Installer.js
@@ -83,8 +83,12 @@ export default function EpinioInstaller({
       setInstalled(false)
       onInstallationChanged(false)
 
+      message = 'Error installing Epinio'
+      if (error.stderr) {
+        message = error.stderr
+      }
       console.error(error)
-      const message = `If the nginx service is stuck in pending state, you might need to restart docker desktop. \n ${JSON.stringify(error)}`
+
       onError(message)
     } finally {
       setProgress(0)
@@ -164,7 +168,7 @@ export default function EpinioInstaller({
       '--create-namespace', '--namespace', 'epinio',
       '--atomic',
       '--set', 'global.domain=' + domain,
-      'https://github.com/epinio/helm-charts/releases/download/epinio-1.11.0-rc1/epinio-1.11.0-rc1.tgz'
+      'https://github.com/epinio/helm-charts/releases/download/epinio-1.11.0/epinio-1.11.0.tgz'
     ])
 
     console.log('installed: epinio')

--- a/ui/src/epinio/Lister.js
+++ b/ui/src/epinio/Lister.js
@@ -10,34 +10,37 @@ export function Lister({ apiDomain, enabled, credentials }) {
   useEffect(() => {
     const fetchApplications = () => {
       const epinioClient = EpinioClient({ apiDomain, credentials })
-      epinioClient.listApplications('workspace')
-        .then(applications => {
-          const t = []
+      epinioClient.login('admin', 'password')
+        .then(
+          epinioClient.listApplications('workspace')
+            .then(applications => {
+              const t = []
 
-          for (let i = 0; i < applications.length; i++) {
-            const app = applications[i]
+              for (let i = 0; i < applications.length; i++) {
+                const app = applications[i]
 
-            t[i] = {
-              id: app.meta.name,
-              state: app.status,
-              instances: app.configuration.instances
-            }
+                t[i] = {
+                  id: app.meta.name,
+                  state: app.status,
+                  instances: app.configuration.instances
+                }
 
-            if (app.deployment) {
-              t[i].dstatus = app.deployment.status
-            }
+                if (app.deployment) {
+                  t[i].dstatus = app.deployment.status
+                }
 
-            if (app.configuration.routes.length > 0) {
-              t[i].route = app.configuration.routes[0]
-            }
-          }
+                if (app.configuration.routes.length > 0) {
+                  t[i].route = app.configuration.routes[0]
+                }
+              }
 
-          setTable(t)
-        })
-        .catch(error => {
-          console.error('error listing applications', error)
-          setTable([])
-        })
+              setTable(t)
+            })
+            .catch(error => {
+              console.error('error listing applications', error)
+              setTable([])
+            })
+        )
     }
 
     if (enabled && credentialsOK(credentials)) {

--- a/ui/src/epinio/Lister.js
+++ b/ui/src/epinio/Lister.js
@@ -10,37 +10,34 @@ export function Lister({ apiDomain, enabled, credentials }) {
   useEffect(() => {
     const fetchApplications = () => {
       const epinioClient = EpinioClient({ apiDomain, credentials })
-      epinioClient.login('admin', 'password')
-        .then(
-          epinioClient.listApplications('workspace')
-            .then(applications => {
-              const t = []
+      epinioClient.listApplications('workspace')
+        .then(applications => {
+          const t = []
 
-              for (let i = 0; i < applications.length; i++) {
-                const app = applications[i]
+          for (let i = 0; i < applications.length; i++) {
+            const app = applications[i]
 
-                t[i] = {
-                  id: app.meta.name,
-                  state: app.status,
-                  instances: app.configuration.instances
-                }
+            t[i] = {
+              id: app.meta.name,
+              state: app.status,
+              instances: app.configuration.instances
+            }
 
-                if (app.deployment) {
-                  t[i].dstatus = app.deployment.status
-                }
+            if (app.deployment) {
+              t[i].dstatus = app.deployment.status
+            }
 
-                if (app.configuration.routes.length > 0) {
-                  t[i].route = app.configuration.routes[0]
-                }
-              }
+            if (app.configuration.routes.length > 0) {
+              t[i].route = app.configuration.routes[0]
+            }
+          }
 
-              setTable(t)
-            })
-            .catch(error => {
-              console.error('error listing applications', error)
-              setTable([])
-            })
-        )
+          setTable(t)
+        })
+        .catch(error => {
+          console.error('error listing applications', error)
+          setTable([])
+        })
     }
 
     if (enabled && credentialsOK(credentials)) {


### PR DESCRIPTION
This PR removes the Nginx ingress to use Traefik only when needed. This will enable Epinio to use the available Traefik on Rancher Desktop.

It also use the epinio CLI instead of the APIs, to avoid problems with the certificates (the CLI will login trusting the self signed certificates.