### PR TITLE
Switch localdev.me (no longer in service) to localtest.me

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #################################
 # Downloader for AMD64 binaries #
 #################################
-FROM alpine as downloader-amd64
+FROM alpine AS downloader-amd64
 
 RUN apk add --no-cache wget coreutils unzip
 
@@ -73,7 +73,7 @@ RUN wget -nv https://github.com/epinio/epinio/releases/download/v${EPINIO_VERSIO
 #################################
 # Downloader for ARM64 binaries #
 #################################
-FROM alpine as downloader-arm64
+FROM alpine AS downloader-arm64
 
 RUN apk add --no-cache wget coreutils unzip
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To install on Rancher Desktop, use the Rancher Desktop CLI `rdctl`.
 If having trouble installing Epinio, you may need to install it manually.
 
 ```
-helm upgrade --install epinio --create-namespace --namespace epinio --atomic --set global.domain=localdev.me https://github.com/epinio/helm-charts/releases/download/epinio-1.11.1/epinio-1.11.1.tgz
+helm upgrade --install epinio --create-namespace --namespace epinio --atomic --set global.domain=localtest.dev https://github.com/epinio/helm-charts/releases/download/epinio-1.11.1/epinio-1.11.1.tgz
 ```
 
 If you receive a "Error: no cached repo found (try 'helm repo update')" error, you may need to try `helm repo update` first.

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -38,8 +38,8 @@ function Opener(props) {
 }
 
 function App() {
-  const domain = 'localdev.me'
-  const uiDomain = 'epinio.localdev.me'
+  const domain = 'localtest.dev'
+  const uiDomain = 'epinio.localtest.dev'
   const [hasKubernetes, setHasKubernetes] = useState(false)
   const [installation, setInstallation] = useState(false)
   const [credentials, setCredentials] = useState({ username: '-', password: '-' })


### PR DESCRIPTION
This switches the default installation to use localtest.me instead of localdev.me (which is no longer in service). This may also be deprecated in the future in favor of Rancher Desktop and Docker Desktop magic URLs or other.

Thanks for pointing this out, Jan Dubois!